### PR TITLE
require node 16 due to adapter-core 3.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "type": "git",
     "url": "https://github.com/simatec/ioBroker.solax"
   },
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "dependencies": {
     "@iobroker/adapter-core": "^3.0.3",
     "axios": "^1.5.0",


### PR DESCRIPTION
Adapter-core 3.x.x is known to fail when installed at node 14 due to npm7 not installing peer dependencies. So this adapter requires node 16