### PR TITLE
Update inverterData.js

### DIFF
--- a/lib/inverterData.js
+++ b/lib/inverterData.js
@@ -54,7 +54,7 @@ class inverterData {
                 7: { /***************************************** X1/X3-EVC ***************************************/
                     0: { name: 'info.totalSize', description: 'Total Size of Power', type: 'number', unit: 'kW', role: 'value.power' },
                     2: { name: 'info.chargerSN', description: 'Unique identifier of charger (Serial No.)', type: 'string', role: 'text' },
-                    4: { name: 'info.version', description: 'Version', type: 'string', role: 'text' },
+                    4: { name: 'info.version', description: 'Version', type: 'number', role: 'text' },
                 }
             };
             resolve(information_dataPoints);
@@ -269,7 +269,7 @@ class inverterData {
                 },
                 7: { /****************************************** X1/X3-EVC Wallbox ************************************/
                     isOnline: { name: 'info.online', description: 'Wallbox Online', type: 'boolean', role: 'switch' },
-                    0: { name: 'data.plugstatus', description: 'Plug Status', type: 'string', role: 'text' }, // '0=Unplugged 1=Plugged 2=Charging': (0, ''),
+                    0: { name: 'data.chargerstatus', description: 'Charger Status', type: 'string', role: 'text' }, // '0=Available 1=Preparing 2=Charging 3=Complete': (0, ''),
                     1: { name: 'data.chargemode', description: 'Charge Mode', type: 'string', role: 'text' }, // '0= Stop 1= Fast 2=Green 3=Eco': (1, ''),
                     2: { name: 'data.acvoltage1', description: 'Grid Voltage 1', type: 'number', multiplier: 0.01, unit: 'V', role: 'value.power' }, // '': (2, 'V'),
                     3: { name: 'data.acvoltage2', description: 'Grid Voltage 2', type: 'number', multiplier: 0.01, unit: 'V', role: 'value.power' }, // '': (3, 'V'),
@@ -286,11 +286,10 @@ class inverterData {
                     19: { name: 'data.gridacpower1', description: 'Grid AC Power 1', type: 'number', maxValue: 32768, unit: 'W', role: 'value.power' }, // '': (19, 'W'),
                     20: { name: 'data.gridacpower2', description: 'Grid AC Power 2', type: 'number', maxValue: 32768, unit: 'W', role: 'value.power' }, // '': (20, 'W'),
                     21: { name: 'data.gridacpower3', description: 'Grid AC Power 3', type: 'number', maxValue: 32768, unit: 'W', role: 'value.power' }, // '': (21, 'W'),
-                    22: { name: 'data.gridacpower', description: 'Grid AC Power', type: 'number', maxValue: 32768, unit: 'W', role: 'value.power' }, // '': (22, 'W'),
                     23: { name: 'data.plugTemperature', description: 'Plug Temperature', type: 'number', unit: '°C', role: 'value.temperature' }, // '': (23, ''),
                     24: { name: 'data.boardTemperature', description: 'Board Temperature', type: 'number', unit: '°C', role: 'value.temperature' }, // '': (24, ''),
-                    26: { name: 'data.plugged', description: 'Car Plugged', type: 'number', role: 'indicator.state' }, // '': (26, ''),
-                    80: { name: 'data.chargeduration', description: 'Charge Duration', type: 'number', unit: 's', role: 'value.time' }, // '': (80, 's')
+                    26: { name: 'data.plugstatus', description: 'Plug Status', type: 'string', role: 'text' }, // '0=Not Connected 1=Connected 2=Charging': (26, ''),
+                    80: { name: 'data.chargedurationinseconds', description: 'Charge Duration in Seconds', type: 'number', unit: 's', role: 'indicator.state' }, // '': (80, 's')
                 }
             };
             resolve(data_dataPoints);


### PR DESCRIPTION
Moin,

ich habe heute mal einige Werte die unklar waren überprüft. Zeile 57: der Fehler "State value to set for "solax.3.info.version" has to be type "string" but received type "number", das ist offensichtlich die Softwareversion der Wallbox gleich zu setzen mit der DSP/ARM Version des X3-Hybrid (Anzeige in der APP). Zeile 272: geändert in Charger Status und die Stati passe ich auch gleich noch in der Main.js an. Die Werte/Beschreibung habe ich 1:1 aus der Solax App übernommen. Zeile 289: der Wert 22 gridacpower stellt mich aktuell noch vor ein Rätsel. In der APP wird er mit Netzleistung angegeben aber wenn der Akku vom Haus geladen wird zeigt er diesen Wert (wenn negativ) an. Erst mal weg lassen. Zeile 291: Wert 26, das ist der Status des Steckers, müsste identisch wie data.chargerstatus und data.chargemode behandelt werden, 0=Not Connected 1=Connected 2=Charging Zeile 292: Wert 80, das ist definitiv die Dauer des aktuellen Ladevorgangs in Sekunden. wenn man den nicht direkt in hh:mm:ss umrechnen/anzeigen lassen kann würde ich den so lassen.

MfG
André